### PR TITLE
修复: 处理相对路径转换为绝对路径的问题

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -22,15 +22,19 @@ def read_config():
         if os.path.exists(str):
             try:
                 config = utils.yaml2dict(str)
+                workPath = os.path.dirname(str)
+                config['template'] = os.path.abspath(os.path.join(workPath, config['template']))
+                config['data'] = os.path.abspath(os.path.join(workPath, config['data']))
+                config['dst'] = os.path.abspath(os.path.join(workPath, config['dst']))
                 if config['template'] is None or not os.path.exists(config['template']):
-                    print(f"模板路径 {config['template']} 不存在, 请重试:")
-                    sys.exit()
+                    print(f"模板路径 {config['template']} 不存在, 请重试:\n")
+                    continue
                 if config['data'] is None or not os.path.exists(config['data']):
-                    print(f"数据路径 {config['data']} 不存在, 请重试:")
-                    sys.exit()
+                    print(f"数据路径 {config['data']} 不存在, 请重试:\n")
+                    continue
                 if config['dst'] is None:
-                    print(f"目标目录 {config['dst']} 不存在, 请重试:")
-                    sys.exit()
+                    print(f"目标目录 {config['dst']} 不存在, 请重试:\n")
+                    continue
                 os.makedirs(config['dst'], exist_ok=True)
                 
                 print("请确认以下信息(输入 Y 并回车确认, 输入其它内容取消操作):")
@@ -53,7 +57,7 @@ def read_config():
             else:
                 return 
         else:
-            print(f"配置文件路径不存在, 请重试:")
+            print(f"配置文件路径不存在, 请重试:\n")
 
 def unzip_docx(docx_path):
     print("正在解压 docx 文档")


### PR DESCRIPTION
修复: 处理相对路径转换为绝对路径的问题

- 修改了 `convert.py` 中的路径处理逻辑，确保配置文件中的相对路径转换为绝对路径
- 确保路径在转换后更加美观，去除了路径中的 `..` 等相对路径符号

新增: 
- 用户输入错误路径不必重新运行，直接重新输入路径即可
- 更新readme和example, 让其适用于新的 `convert.py` 中的特性

close #5  close #3 